### PR TITLE
chore: Updating `dependabot.yml` to only allow `minor` and `patch` updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,6 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+    update-types:
+      - "minor"
+      - "patch"


### PR DESCRIPTION
This PR updates `dependabot.yml` to only allow `minor` and `patch` updates.